### PR TITLE
Allow customization of which env var is used to store the Stripe API Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ or if you are on heroku:
 heroku config:add STRIPE_API_KEY=sk_test_xxyyzz
 ```
 
+If you need to read the API Key from a different environment variable, you can specify which variable like so:
+
+```ruby
+config.stripe.env_var = "EXAMPLE_STRIPE_API_KEY"
+```
+
 You can also set this value from inside ruby configuration code:
 
 ```ruby

--- a/app/views/stripe/_js.html.erb
+++ b/app/views/stripe/_js.html.erb
@@ -1,7 +1,7 @@
 <% if Rails.application.config.stripe.debug_js %>
-<script type="text/javascript" src="https://js.stripe.com/v1/stripe-debug.js"></script>
+<script type="text/javascript" src="https://js.stripe.com/v2/stripe-debug.js"></script>
 <% else %>
-<script type="text/javascript" src="https://js.stripe.com/v1/"></script>
+<script type="text/javascript" src="https://js.stripe.com/v2/"></script>
 <% end %>
 <script type="text/javascript">
 Stripe.setPublishableKey("<%= Rails.application.config.stripe.publishable_key or fail 'No stripe.com publishable key found. Please set config.stripe.publishable_key in config/application.rb to one of your publishable keys, which can be found here: https://manage.stripe.com/#account/apikeys' %>")

--- a/lib/stripe/engine.rb
+++ b/lib/stripe/engine.rb
@@ -8,11 +8,12 @@ module Stripe
       attr_accessor :testing
     end
 
-    config.stripe = Struct.new(:api_base, :api_key, :verify_ssl_certs, :publishable_key, :endpoint, :debug_js).new
+    config.stripe = Struct.new(:api_base, :api_key, :verify_ssl_certs, :publishable_key, :endpoint, :env_var, :debug_js).new
 
     initializer 'stripe.configure.defaults', :before => 'stripe.configure' do |app|
       stripe = app.config.stripe
-      stripe.api_key ||= ENV['STRIPE_API_KEY']
+      stripe.env_var ||= 'STRIPE_API_KEY'
+      stripe.api_key ||= ENV[stripe.env_var]
       stripe.endpoint ||= '/stripe'
       if stripe.debug_js.nil?
         stripe.debug_js = ::Rails.env.development?


### PR DESCRIPTION
Running multiple apps locally, I can't set the STRIPE_API_KEY var since it will clash with other apps. Instead, I use env vars like APP_NAME_STRIPE_API_KEY which currently are not recognized by stripe-rails. This update allows a config var to be set in the app allowing customization of which env var is used to store the Stripe API Key.
