### PR TITLE
added api versioning

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+## 0.2.6 (2013-07-12)
+* add config.stripe.api_version setting to support api versioning
+
 ## 0.2.5 (2013-03-18)
 * make the default max redemptions 1
 * add stripe::coupons::reset! task to redefine all coupons

--- a/app/views/stripe/_js.html.erb
+++ b/app/views/stripe/_js.html.erb
@@ -1,7 +1,7 @@
 <% if Rails.application.config.stripe.debug_js %>
-<script type="text/javascript" src="https://js.stripe.com/v1/stripe-debug.js"></script>
+<%= javascript_include_tag "https://js.stripe.com/#{Rails.application.config.stripe.version}/stripe-debug.js"
 <% else %>
-<script type="text/javascript" src="https://js.stripe.com/v1/"></script>
+<%= javascript_include_tag "https://js.stripe.com/#{Rails.application.config.stripe.version}/stripe.js"
 <% end %>
 <script type="text/javascript">
 Stripe.setPublishableKey("<%= Rails.application.config.stripe.publishable_key or fail 'No stripe.com publishable key found. Please set config.stripe.publishable_key in config/application.rb to one of your publishable keys, which can be found here: https://manage.stripe.com/#account/apikeys' %>")

--- a/app/views/stripe/_js.html.erb
+++ b/app/views/stripe/_js.html.erb
@@ -1,7 +1,7 @@
 <% if Rails.application.config.stripe.debug_js %>
-<%= javascript_include_tag "https://js.stripe.com/#{Rails.application.config.stripe.version}/stripe-debug.js"
+<%= javascript_include_tag "https://js.stripe.com/#{Rails.application.config.stripe.api_version}/stripe-debug.js"
 <% else %>
-<%= javascript_include_tag "https://js.stripe.com/#{Rails.application.config.stripe.version}/stripe.js"
+<%= javascript_include_tag "https://js.stripe.com/#{Rails.application.config.stripe.api_version}/stripe.js"
 <% end %>
 <script type="text/javascript">
 Stripe.setPublishableKey("<%= Rails.application.config.stripe.publishable_key or fail 'No stripe.com publishable key found. Please set config.stripe.publishable_key in config/application.rb to one of your publishable keys, which can be found here: https://manage.stripe.com/#account/apikeys' %>")

--- a/lib/stripe/engine.rb
+++ b/lib/stripe/engine.rb
@@ -8,11 +8,12 @@ module Stripe
       attr_accessor :testing
     end
 
-    config.stripe = Struct.new(:api_base, :api_key, :verify_ssl_certs, :publishable_key, :endpoint, :debug_js).new
+    config.stripe = Struct.new(:api_base, :api_key, :api_version, :verify_ssl_certs, :publishable_key, :endpoint, :debug_js).new
 
     initializer 'stripe.configure.defaults', :before => 'stripe.configure' do |app|
       stripe = app.config.stripe
       stripe.api_key ||= ENV['STRIPE_API_KEY']
+      stripe.api_version ||= 'v1'
       stripe.endpoint ||= '/stripe'
       if stripe.debug_js.nil?
         stripe.debug_js = ::Rails.env.development?

--- a/lib/stripe/rails/version.rb
+++ b/lib/stripe/rails/version.rb
@@ -1,5 +1,5 @@
 module Stripe
   module Rails
-    VERSION = "0.2.5"
+    VERSION = "0.2.6"
   end
 end


### PR DESCRIPTION
Stripe offers two api versions already (v1 and v2). The version should be easily configurable!
