### PR TITLE
Add support for weekly plans.

### DIFF
--- a/lib/stripe/plans.rb
+++ b/lib/stripe/plans.rb
@@ -7,7 +7,7 @@ module Stripe
       attr_accessor :name, :amount, :interval, :interval_count, :trial_period_days
 
       validates_presence_of :id, :name, :amount
-      validates_inclusion_of :interval, :in => %w(month year), :message => "'%{value}' is not one of 'month' or 'year'"
+      validates_inclusion_of :interval, :in => %w(week month year), :message => "'%{value}' is not one of 'week', 'month' or 'year'"
 
       def initialize(*args)
         super(*args)

--- a/test/plan_builder_spec.rb
+++ b/test/plan_builder_spec.rb
@@ -29,6 +29,46 @@ describe 'building plans' do
       Stripe::Plans['primo'].must_equal Stripe::Plans::PRIMO
     end
 
+    it 'accepts a billing interval of a week' do
+      Stripe.plan :weekly do |plan|
+        plan.name = 'Acme as a service weekly'
+        plan.amount = 100
+        plan.interval = 'week'
+      end
+
+      Stripe::Plans::WEEKLY.wont_be_nil
+    end
+
+    it 'accepts a billing interval of a month' do
+      Stripe.plan :monthly do |plan|
+        plan.name = 'Acme as a service monthly'
+        plan.amount = 400
+        plan.interval = 'month'
+      end
+
+      Stripe::Plans::MONTHLY.wont_be_nil
+    end
+
+    it 'accepts a billing interval of a year' do
+      Stripe.plan :yearly do |plan|
+        plan.name = 'Acme as a service yearly'
+        plan.amount = 4800
+        plan.interval = 'year'
+      end
+
+      Stripe::Plans::YEARLY.wont_be_nil
+    end
+
+    it 'denies arbitrary billing intervals' do
+      lambda {
+        Stripe.plan :broken do |plan|
+          plan.name = 'Acme as a service BROKEN'
+          plan.amount = 999
+          plan.interval = 'anything'
+        end
+      }.must_raise Stripe::InvalidConfigurationError
+    end
+
     describe 'uploading' do
       describe 'when none exists on stripe.com' do
         before do


### PR DESCRIPTION
Currently, stripe-rails only accepts values of "month" and "year" for plan intervals. However, [the Stripe API allows "week" as an option](https://stripe.com/docs/api/ruby#plan_object) to create plans that bill each week. This pull request addresses the issue and adds some tests to make sure "week", "month", and "year" all work while still rejecting arbitrary values for the plan interval.

Thanks for the work on this - it definitely helps to not have to recreate the wheel!
