### PR TITLE
Add config option to disable automatic mounting of engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,20 @@ config.stripe.endpoint = '/payment/stripe-integration'
 
 Your new webook URL would then be `http://myproductionapp/payment/stripe-integration/events`
 
+### Disabling auto mount
+
+If you don't want the engine to be auto mounted, e.g. if you need to include it in a specific
+place in your route definitions due to a catch-all route, you can disable auto mounting and
+mount the engine manually:
+
+```ruby
+# in application.rb
+config.stripe.auto_mount = false
+
+# in your application's routes.rb:
+mount Stripe::Engine => "/stripe"
+```
+
 ### Responding to webhooks
 
 Once you have your webhook URL configured you can respond to a stripe webhook *anywhere* in your

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-  mount Stripe::Engine => Rails.application.config.stripe.endpoint
+  if Rails.application.config.stripe.auto_mount
+    mount Stripe::Engine => Rails.application.config.stripe.endpoint
+  end
 end
 
 Stripe::Engine.routes.draw do

--- a/lib/stripe/engine.rb
+++ b/lib/stripe/engine.rb
@@ -8,12 +8,13 @@ module Stripe
       attr_accessor :testing
     end
 
-    config.stripe = Struct.new(:api_base, :api_key, :verify_ssl_certs, :publishable_key, :endpoint, :debug_js).new
+    config.stripe = Struct.new(:api_base, :api_key, :verify_ssl_certs, :publishable_key, :endpoint, :debug_js, :auto_mount).new
 
     initializer 'stripe.configure.defaults', :before => 'stripe.configure' do |app|
       stripe = app.config.stripe
       stripe.api_key ||= ENV['STRIPE_API_KEY']
       stripe.endpoint ||= '/stripe'
+      stripe.auto_mount = true if stripe.auto_mount.nil?
       if stripe.debug_js.nil?
         stripe.debug_js = ::Rails.env.development?
       end


### PR DESCRIPTION
If you have a catch-all route in your rails application (e.g. because you are using pushstate and want to render the same thing on every page and sort it out in JS), you need to explicitly mount engines before the catch-all route.

However, if the engine is auto-mounted, manually mounting the engine causes an error on application boot.

I added a config switch that disables auto mounting so that you can manually mount the engine at the appropriate place in your application's routes.
