### PR TITLE
Rename api_key to secret_key

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,5 @@
+* Rename api_key to secret_key
+
 ## 0.2.6 (2013-10-17)
 * add `auto_mount` option to allow for manually mounting the webhook endpoints
 

--- a/README.md
+++ b/README.md
@@ -46,22 +46,22 @@ config.stripe.debug_js = false # use stripe.js
 
 You will need to configure your application to authenticate with stripe.com
 using [your api key][1]. There are two methods to do this, you can either set the environment
-variable `STRIPE_API_KEY`:
+variable `STRIPE_SECRET_KEY`:
 
 ```sh
-export STRIPE_API_KEY=sk_test_xxyyzz
+export STRIPE_SECRET_KEY=sk_test_xxyyzz
 ```
 
 or if you are on heroku:
 
 ```sh
-heroku config:add STRIPE_API_KEY=sk_test_xxyyzz
+heroku config:add STRIPE_SECRET_KEY=sk_test_xxyyzz
 ```
 
 You can also set this value from inside ruby configuration code:
 
 ```ruby
-config.stripe.api_key = "sk_test_xxyyzz"
+config.stripe.secret_key = "sk_test_xxyyzz"
 ```
 
 In either case, it is recommended that you *not* check in this value into source control.

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -1,6 +1,6 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
-ENV['STRIPE_API_KEY'] = 'XYZ'
+ENV['STRIPE_SECRET_KEY'] = 'XYZ'
 
 require File.expand_path("../dummy/config/environment.rb",  __FILE__)
 require "rails/test_help"


### PR DESCRIPTION
Addresses #16

Although weirdly Stripe's own gem calls it `api_key`. But their gem is not a great example of stellar coding tbh...
