### PR TITLE
Remove authenticity token check

### DIFF
--- a/app/controllers/stripe/application_controller.rb
+++ b/app/controllers/stripe/application_controller.rb
@@ -1,5 +1,6 @@
 module Stripe
   class ApplicationController < ActionController::Base
+    skip_before_action :verify_authenticity_token
     # is anything stripe wide?
   end
 end


### PR DESCRIPTION
Stripe webhooks were not working in production using Rails 4 so I added an authenticity token skip
