### PR TITLE
add metadata to plans

### DIFF
--- a/lib/stripe/plans.rb
+++ b/lib/stripe/plans.rb
@@ -3,7 +3,7 @@ module Stripe
     include ConfigurationBuilder
 
     configuration_for :plan do
-      attr_accessor :name, :amount, :interval, :interval_count, :trial_period_days, :currency
+      attr_accessor :name, :amount, :interval, :interval_count, :trial_period_days, :currency, :metadata
 
       validates_presence_of :id, :name, :amount
       validates_inclusion_of :interval, :in => %w(week month year), :message => "'%{value}' is not one of 'week', 'month' or 'year'"
@@ -22,7 +22,8 @@ module Stripe
           :amount => @amount,
           :interval => @interval,
           :interval_count => @interval_count,
-          :trial_period_days => @trial_period_days
+          :trial_period_days => @trial_period_days,
+          :metadata => @metadata
         }
       end
     end

--- a/test/plan_builder_spec.rb
+++ b/test/plan_builder_spec.rb
@@ -10,6 +10,7 @@ describe 'building plans' do
         plan.interval = 'month'
         plan.interval_count = 3
         plan.trial_period_days = 30
+        plan.metadata = {:number_of_awesome_things => 5}
       end
     end
     after do
@@ -83,7 +84,8 @@ describe 'building plans' do
             :amount => 699,
             :interval => 'month',
             :interval_count => 1,
-            :trial_period_days => 0
+            :trial_period_days => 0,
+            :metadata => nil
           )
           Stripe::Plans::GOLD.put!
         end
@@ -96,7 +98,8 @@ describe 'building plans' do
             :amount => 699,
             :interval => 'month',
             :interval_count => 1,
-            :trial_period_days => 0
+            :trial_period_days => 0,
+            :metadata => nil
           )
           Stripe::Plans::ALTERNATIVE_CURRENCY.put!
         end


### PR DESCRIPTION
To allow for plans to have different information attached to them (one
use case would be when providing a pricing table) a metadata field has
been added.

This code is pretty much ripped off from https://github.com/thefrontside/stripe-rails/pull/14 but it does fix the tests and merge conflicts on the other pull request.
