### PR TITLE
Adding timeout options to git config

### DIFF
--- a/lib/stripe/engine.rb
+++ b/lib/stripe/engine.rb
@@ -8,7 +8,7 @@ module Stripe
       attr_accessor :testing
     end
 
-    stripe_config = config.stripe = Struct.new(:api_base, :secret_key, :verify_ssl_certs, :publishable_key, :endpoint, :debug_js, :auto_mount, :eager_load).new
+    stripe_config = config.stripe = Struct.new(:api_base, :secret_key, :verify_ssl_certs, :publishable_key, :endpoint, :debug_js, :auto_mount, :eager_load, :open_timeout, :read_timeout).new
 
     def stripe_config.api_key=(key)
       warn "[DEPRECATION] to align with stripe nomenclature, stripe.api_key has been renamed to config.stripe.secret_key"


### PR DESCRIPTION
On 12/8/2014, a change was merged to the Stripe ruby gem that allowed developers to configure the open and read timeout values when connecting to Stripe:
https://github.com/stripe/stripe-ruby/issues/46
https://github.com/stripe/stripe-ruby/pull/74

This PR passes along these config options from stripe-rails to the stripe ruby gem.
