### PR TITLE
Fix master tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,4 @@ gem "rake"
 gem 'tzinfo'
 gem 'mocha'
 gem 'pry'
+gem 'responders', '~> 2.0'

--- a/lib/stripe/callbacks/builder.rb
+++ b/lib/stripe/callbacks/builder.rb
@@ -40,7 +40,7 @@ module Stripe
                 block.call(target, evt) if only.call(target, evt)
               end
             when Array, Set
-              stringified_keys = only.map(&:to_s)
+              stringified_keys = only.map(&:to_sym)
               proc do |target, evt|
                 intersection =  evt.data.previous_attributes.keys - stringified_keys
                 block.call(target, evt) if intersection != evt.data.previous_attributes.keys

--- a/test/callbacks_spec.rb
+++ b/test/callbacks_spec.rb
@@ -156,7 +156,7 @@ describe Stripe::Callbacks do
     describe 'specified as a lambda' do
       before do
         @observer.class_eval do
-          after_invoice_updated :only => proc {|target, evt| evt.data.previous_attributes.has_key? "closed"} do |i,e|
+          after_invoice_updated :only => proc {|target, evt| evt.data.previous_attributes.to_h.has_key? :closed} do |i,e|
             events << e
           end
         end


### PR DESCRIPTION
I was going to propose a small PR for rails 5 compatibility and saw that master was failing. Here is a quick fix

I'm not entirely sure if I'm treating the symptom or the problem here. 

For the failing assertions on `test/callbacks_spec.rb:135` and `test/callbacks_spec.rb:153`, the keys were strings when `evt.data.previous_attributes.keys` were symbols. 

For the failing assertion on `test/callbacks_spec.rb:172`, within the proc in the test, `evt.data.previous_attributes` was straight up JSON, 

Again, the tests are passing, but I'm not sure if this is _fixed_. It's not clear to me why it would of worked in the past as strings and now be symbols.
